### PR TITLE
Fix volatile variables for ISR

### DIFF
--- a/SmartTap - Phase 2/project.c
+++ b/SmartTap - Phase 2/project.c
@@ -5,7 +5,8 @@
 #include <stdio.h>
 
 char buffer[20];
-int second = 0 , minute = 0 , hour = 0 , flag1 = 0 , flag2 = 0;
+volatile int second = 0 , minute = 0 , hour = 0 ;
+int flag1 = 0 , flag2 = 0;
 
 interrupt [TIM1_OVF] void timer1_ovf_isr(void)
 {

--- a/SmartTap - Phase 3/test.c
+++ b/SmartTap - Phase 3/test.c
@@ -2,7 +2,7 @@
 This program was created by the
 CodeWizardAVR V3.12 Advanced
 Automatic Program Generator
-© Copyright 1998-2014 Pavel Haiduc, HP InfoTech s.r.l.
+Â© Copyright 1998-2014 Pavel Haiduc, HP InfoTech s.r.l.
 http://www.hpinfotech.com
 
 Project : Smart Water Tap
@@ -26,10 +26,10 @@ Data Stack size         : 256
 #include <stdio.h>
 
 // Declare your global variables here
-int hour = 0;
-int minute = 0;
-int second = 0;
-unsigned char is_on = 0;
+volatile int hour = 0;
+volatile int minute = 0;
+volatile int second = 0;
+volatile unsigned char is_on = 0;
 
 /*
     LCD DRIVER By Seyyed Ali Ayati


### PR DESCRIPTION
## Summary
- mark shared time state and control flag as `volatile`

## Testing
- `avr-gcc 'SmartTap - Phase 3/test.c' -o /tmp/test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ba1ec0dc8328b6bc7662f60ca23f