### PR TITLE
Fix typo in SmartTap Phase 2 code comment

### DIFF
--- a/SmartTap - Phase 2/project.c
+++ b/SmartTap - Phase 2/project.c
@@ -23,7 +23,7 @@ if (hour == 24) hour = 0;
 void main(void)
 {
 
-//tanzim portA b onvane voooroodi - bekhatere ADC
+//tanzim portA b onvane voroodi - bekhatere ADC
 DDRA=0x00;
 PORTA=0x00;
 //tanzim portB b onvane khoorooji 


### PR DESCRIPTION
## Summary
- correct `voooroodi` typo to `voroodi` in Phase 2 project

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6841fece9d2c8328bad5ae43b614c180